### PR TITLE
fix: auto-register a step before non-top-level calls; add `drop_last_step`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime_tracing"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime_tracing"
-version = "0.5.12"
+version = "0.5.12-experimental-1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime_tracing"
-version = "0.5.12-experimental-1"
+version = "0.5.12-experimental-2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,9 +27,11 @@ mod tests {
         
         let args = vec![tracer.arg("a", NONE_VALUE), tracer.arg("b", NONE_VALUE)];
         tracer.register_call(function_id, args);
-        // => arg-related variable/value events; auto call-step event; call event
+        // => arg-related variable/value events; auto call-step event; potentially variables; call event
 
-        assert!(tracer.events.len() > 1);
+        assert!(tracer.events.len() > 3);
+        // println!("{:#?}", tracer.events);
+        // -4, -3 should be variables
         let should_be_step = &tracer.events[tracer.events.len() - 2];
         let should_be_call = &tracer.events[tracer.events.len() - 1];
         if let TraceLowLevelEvent::Step(StepRecord { path_id, line }) = should_be_step {
@@ -61,7 +63,7 @@ mod tests {
 
         tracer.register_return(NONE_VALUE);
 
-        assert_eq!(tracer.events.len(), 19);
+        assert_eq!(tracer.events.len(), 21);
         // visible with
         // cargo tets -- --nocapture
         // println!("{:#?}", tracer.events);

--- a/src/tracer.rs
+++ b/src/tracer.rs
@@ -126,11 +126,16 @@ impl Tracer {
         // non-toplevel calls, so
         // we ensure it directly from register_call
         if function_id != TOP_LEVEL_FUNCTION_ID {
+            for arg in &args {
+                self.register_full_value(arg.variable_id, arg.value.clone());
+            }
             let function = &self.function_list[function_id.0];
             self.events.push(TraceLowLevelEvent::Step(StepRecord { 
                 path_id: function.1,
                 line: function.2
             }));
+
+            
         }
         // the actual call event:
         self.events.push(TraceLowLevelEvent::Call(CallRecord { function_id, args }));

--- a/src/tracer.rs
+++ b/src/tracer.rs
@@ -179,6 +179,10 @@ impl Tracer {
         self.events.push(TraceLowLevelEvent::Value(FullValueRecord { variable_id, value }));
     }
 
+    pub fn drop_last_step(&mut self) {
+        self.events.push(TraceLowLevelEvent::DropLastStep);
+    }
+
     pub fn store_trace_metadata(&self, path: &Path) -> Result<(), Box<dyn Error>> {
         let trace_metadata = TraceMetadata {
             program: self.program.clone(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -62,7 +62,7 @@ pub const NO_KEY: CallKey = CallKey(-1);
 
 // end of call keys code
 
-#[derive(Debug, Default, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Copy, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(transparent)]
 pub struct Line(pub i64);
 
@@ -123,7 +123,7 @@ impl Into<usize> for VariableId {
     }
 }
 
-#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq)]
 pub struct FunctionId(pub usize);
 
 impl Into<usize> for FunctionId {

--- a/src/types.rs
+++ b/src/types.rs
@@ -17,6 +17,7 @@ pub enum TraceLowLevelEvent {
     Call(CallRecord),
     Return(ReturnRecord),
     Event(RecordEvent),
+    DropLastStep,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
`top level` here means the artificial call that contains all top-level code that's not in another call