### PR TITLE
feat: add Reference values and some "raw" register type helpers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime_tracing"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 authors = ["Metacraft Labs Ltd"]
 description = "A library for the schema and tracing helpers for the CodeTracer db trace format"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,9 +113,24 @@ mod tests {
         let rvalue_2 = tracer.compound_rvalue(&["variable2".to_string(), "variable3".to_string()]);
         tracer.assign("variable1", rvalue_2, PassBy::Value);
 
+        // example for reference types
+        let reference_type = TypeRecord {
+            kind: TypeKind::Pointer,
+            lang_type: "MyReference<Int>".to_string(),
+            specific_info: TypeSpecificInfo::Pointer { 
+                dereference_type_id: tracer.ensure_type_id(TypeKind::Int, "Int")
+            }
+        };
+        let reference_type_id = tracer.ensure_raw_type_id(reference_type);
+        let _reference_value = ValueRecord::Reference {
+            dereferenced: Box::new(int_value_1.clone()),
+            mutable: false,
+            type_id: reference_type_id,
+        };
+
         tracer.drop_variables(&["variable1".to_string(), "variable2".to_string(), "variable3".to_string()]);
 
-        assert_eq!(tracer.events.len(), 46);
+        assert_eq!(tracer.events.len(), 47);
         // visible with
         // cargo tets -- --nocapture
         // println!("{:#?}", tracer.events);

--- a/src/tracer.rs
+++ b/src/tracer.rs
@@ -88,11 +88,16 @@ impl Tracer {
     }
 
     pub fn ensure_type_id(&mut self, kind: TypeKind, lang_type: &str) -> TypeId {
-        if !self.types.contains_key(lang_type) {
-            self.types.insert(lang_type.to_string(), TypeId(self.types.len()));
-            self.register_type(kind, lang_type);
+        let typ = self.to_raw_type(kind, lang_type);
+        self.ensure_raw_type_id(typ)
+    }
+
+    pub fn ensure_raw_type_id(&mut self, typ: TypeRecord) -> TypeId {
+        if !self.types.contains_key(&typ.lang_type) {
+            self.types.insert(typ.lang_type.clone(), TypeId(self.types.len()));
+            self.register_raw_type(typ.clone());
         }
-        *self.types.get(lang_type).unwrap()
+        *self.types.get(&typ.lang_type).unwrap()
     }
 
     pub fn ensure_variable_id(&mut self, variable_name: &str) -> VariableId {
@@ -157,12 +162,20 @@ impl Tracer {
         }));
     }
 
-    pub fn register_type(&mut self, kind: TypeKind, lang_type: &str) {
-        let typ = TypeRecord {
+    pub fn to_raw_type(&self, kind: TypeKind, lang_type: &str) -> TypeRecord {
+        TypeRecord {
             kind,
             lang_type: lang_type.to_string(),
             specific_info: TypeSpecificInfo::None,
-        };
+        }
+    }
+
+    pub fn register_type(&mut self, kind: TypeKind, lang_type: &str) {
+        let typ = self.to_raw_type(kind, lang_type);
+        self.events.push(TraceLowLevelEvent::Type(typ));
+    }
+
+    pub fn register_raw_type(&mut self, typ: TypeRecord) {
         self.events.push(TraceLowLevelEvent::Type(typ));
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -280,7 +280,7 @@ pub struct VariableRecord {
 pub struct TypeRecord {
     pub kind: TypeKind,
     pub lang_type: String,
-    // for now only for Struct: TODO eventually
+    // for now only for Struct and Pointer: TODO eventually
     // replace with an enum for TypeRecord, or with more cases
     // in TypeSpecificInfo for collections, etc
     pub specific_info: TypeSpecificInfo,
@@ -297,6 +297,7 @@ pub struct FieldTypeRecord {
 pub enum TypeSpecificInfo {
     None,
     Struct { fields: Vec<FieldTypeRecord> },
+    Pointer { dereference_type_id: TypeId },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -340,8 +341,8 @@ pub enum ValueRecord {
     },
     Sequence {
         elements: Vec<ValueRecord>,
-        type_id: TypeId,
         is_slice: bool,
+        type_id: TypeId,
     },
     Tuple {
         elements: Vec<ValueRecord>,
@@ -354,6 +355,13 @@ pub enum ValueRecord {
     Variant {
         discriminator: String,      // TODO: eventually a more specific kind of value/type
         contents: Box<ValueRecord>, // usually a Struct or a Tuple
+        type_id: TypeId,
+    },
+    // TODO: eventually add more pointer-like variants
+    // or more fields (address?)
+    Reference {
+        dereferenced: Box<ValueRecord>,
+        mutable: bool,
         type_id: TypeId,
     },
     Raw {


### PR DESCRIPTION
we are calling the directly constructed TypeRecord raw here, to preserve backward compatibility: the `_type` helpers accept a kind and a name for the simpler cases.

We might change that API in the future, as there are possible improvements and reforms to type/values