### PR TITLE
feat: support new "_Other" event kinds; add address to Reference

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime_tracing"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 authors = ["Metacraft Labs Ltd"]
 description = "A library for the schema and tracing helpers for the CodeTracer db trace format"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,13 +117,14 @@ mod tests {
         let reference_type = TypeRecord {
             kind: TypeKind::Pointer,
             lang_type: "MyReference<Int>".to_string(),
-            specific_info: TypeSpecificInfo::Pointer { 
-                dereference_type_id: tracer.ensure_type_id(TypeKind::Int, "Int")
-            }
+            specific_info: TypeSpecificInfo::Pointer {
+                dereference_type_id: tracer.ensure_type_id(TypeKind::Int, "Int"),
+            },
         };
         let reference_type_id = tracer.ensure_raw_type_id(reference_type);
         let _reference_value = ValueRecord::Reference {
             dereferenced: Box::new(int_value_1.clone()),
+            address: 0,
             mutable: false,
             type_id: reference_type_id,
         };

--- a/src/tracer.rs
+++ b/src/tracer.rs
@@ -155,9 +155,11 @@ impl Tracer {
         self.events.push(TraceLowLevelEvent::Return(ReturnRecord { return_value }));
     }
 
+    // TODO: add metadata arg
     pub fn register_special_event(&mut self, kind: EventLogKind, content: &str) {
         self.events.push(TraceLowLevelEvent::Event(RecordEvent {
             kind,
+            metadata: "".to_string(),
             content: content.to_string(),
         }));
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -303,6 +303,7 @@ pub enum TypeSpecificInfo {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RecordEvent {
     pub kind: EventLogKind,
+    pub metadata: String,
     pub content: String,
 }
 
@@ -444,8 +445,10 @@ pub enum EventLogKind {
     #[default]
     Write,
     WriteFile,
+    WriteOther,
     Read,
     ReadFile,
+    ReadOther,
     // not used for now
     ReadDir,
     OpenDir,

--- a/src/types.rs
+++ b/src/types.rs
@@ -362,6 +362,7 @@ pub enum ValueRecord {
     // or more fields (address?)
     Reference {
         dereferenced: Box<ValueRecord>,
+        address: u64,
         mutable: bool,
         type_id: TypeId,
     },


### PR DESCRIPTION
for a time this was also tagged as 0.6.1 and used separately, but now we'll try to use 0.10.0 in a noir branch/db-backend