### PR TITLE
Add i128 value support

### DIFF
--- a/docs/trace_json_spec.md
+++ b/docs/trace_json_spec.md
@@ -189,6 +189,7 @@ A special marker used when a previously emitted `Step` should be ignored. It kee
 Many events embed `ValueRecord` objects. They all use an internally tagged representation with a `kind` field. The possible variants are:
 
 * `Int` – `{ "kind": "Int", "i": number, "type_id": TypeId }`
+* `Int128` – `{ "kind": "Int128", "i": number, "type_id": TypeId }`
 * `Float` – `{ "kind": "Float", "f": number, "type_id": TypeId }`
 * `Bool` – `{ "kind": "Bool", "b": true|false, "type_id": TypeId }`
 * `String` – `{ "kind": "String", "text": "...", "type_id": TypeId }`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,4 +155,14 @@ mod tests {
         assert_eq!(a, b);
         assert_ne!(a, different);
     }
+
+    #[test]
+    fn test_i128_value_record() {
+        let a = ValueRecord::Int128 { i: 0, type_id: TypeId(0) };
+        let b = ValueRecord::Int128 { i: 0, type_id: TypeId(0) };
+        let different = ValueRecord::Int128 { i: 1, type_id: TypeId(0) };
+
+        assert_eq!(a, b);
+        assert_ne!(a, different);
+    }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -334,6 +334,10 @@ pub enum ValueRecord {
         i: i64,
         type_id: TypeId,
     },
+    Int128 {
+        i: i128,
+        type_id: TypeId,
+    },
     Float {
         f: f64,
         type_id: TypeId,


### PR DESCRIPTION
## Summary
- support i128 values
- document the new Int128 value record type
- test equality for Int128 values

## Testing
- `cargo test` *(fails: failed to download crates)*