### PR TITLE
Add binary trace roundtrip test

### DIFF
--- a/runtime_tracing/tests/binary_format.rs
+++ b/runtime_tracing/tests/binary_format.rs
@@ -1,0 +1,32 @@
+use runtime_tracing::{TraceEventsFileFormat, Tracer};
+use std::path::Path;
+use std::fs;
+
+#[test]
+fn test_binary_roundtrip() {
+    let json_path = Path::new("tests/data/trace.json");
+
+    let mut tracer = Tracer::new("", &[]);
+    tracer
+        .load_trace_events(json_path, TraceEventsFileFormat::Json)
+        .unwrap();
+    let original = tracer.events.clone();
+
+    let bin_path = Path::new("tests/data/trace.bin");
+
+    tracer
+        .store_trace_events(bin_path, TraceEventsFileFormat::Binary)
+        .unwrap();
+
+    let mut tracer2 = Tracer::new("", &[]);
+    tracer2
+        .load_trace_events(bin_path, TraceEventsFileFormat::Binary)
+        .unwrap();
+
+    fs::remove_file(bin_path).unwrap();
+
+    let orig_json = serde_json::to_string(&original).unwrap();
+    let new_json = serde_json::to_string(&tracer2.events).unwrap();
+
+    assert_eq!(orig_json, new_json);
+}

--- a/runtime_tracing/tests/data/trace.json
+++ b/runtime_tracing/tests/data/trace.json
@@ -1,0 +1,7 @@
+[
+  {"Path":"foo.rs"},
+  {"Function":{"path_id":0,"line":1,"name":"main"}},
+  {"Step":{"path_id":0,"line":1}},
+  {"Call":{"function_id":0,"args":[]}},
+  {"Return":{"return_value":{"kind":"None","type_id":0}}}
+]


### PR DESCRIPTION
## Summary
- add binary_format test to verify JSON ↔ binary conversion
- include small sample trace.json for tests

## Testing
- `cargo test -q`

------
https://chatgpt.com/codex/tasks/task_b_6854ad1735b0832bbf095b062ca71f9b