### PR TITLE
feat: added events for thread support - ThreadStart, ThreadExit, ThreadSwitch

### DIFF
--- a/runtime_tracing/src/abstract_trace_writer.rs
+++ b/runtime_tracing/src/abstract_trace_writer.rs
@@ -7,9 +7,7 @@ use std::{
 };
 
 use crate::{
-    AssignCellRecord, AssignCompoundItemRecord, AssignmentRecord, CallRecord, CellValueRecord, CompoundValueRecord, FullValueRecord, FunctionId,
-    FunctionRecord, Line, NONE_TYPE_ID, PathId, RValue, RecordEvent, ReturnRecord, StepRecord, TraceLowLevelEvent, TraceMetadata, TypeId, TypeKind,
-    TypeRecord, TypeSpecificInfo, VariableCellRecord, VariableId, tracer::TOP_LEVEL_FUNCTION_ID,
+    tracer::TOP_LEVEL_FUNCTION_ID, AssignCellRecord, AssignCompoundItemRecord, AssignmentRecord, CallRecord, CellValueRecord, CompoundValueRecord, FullValueRecord, FunctionId, FunctionRecord, Line, PathId, RValue, RecordEvent, ReturnRecord, StepRecord, ThreadId, TraceLowLevelEvent, TraceMetadata, TypeId, TypeKind, TypeRecord, TypeSpecificInfo, VariableCellRecord, VariableId, NONE_TYPE_ID
 };
 
 pub struct AbstractTraceWriterData {
@@ -278,6 +276,18 @@ pub trait AbstractTraceWriter {
             .map(|variable_dependency| self.ensure_variable_id(variable_dependency))
             .collect();
         RValue::Compound(variable_ids)
+    }
+
+    fn thread_start(&mut self, thread_id: ThreadId) {
+        self.add_event(TraceLowLevelEvent::ThreadStart(thread_id));
+    }
+
+    fn thread_exit(&mut self, thread_id: ThreadId) {
+        self.add_event(TraceLowLevelEvent::ThreadExit(thread_id));
+    }
+
+    fn thread_switch(&mut self, thread_id: ThreadId) {
+        self.add_event(TraceLowLevelEvent::ThreadSwitch(thread_id));
     }
 
     fn drop_last_step(&mut self) {

--- a/runtime_tracing/src/capnptrace.rs
+++ b/runtime_tracing/src/capnptrace.rs
@@ -441,6 +441,18 @@ pub fn write_trace(q: &[crate::TraceLowLevelEvent], output: &mut impl std::io::W
                 let mut ret_place = ret.init_place();
                 ret_place.set_p(vcr.place.0.try_into().unwrap());
             }
+            TraceLowLevelEvent::ThreadStart(tid) => {
+                let mut ret = event.init_thread_start();
+                ret.set_i(tid.0);
+            }
+            TraceLowLevelEvent::ThreadExit(tid) => {
+                let mut ret = event.init_thread_exit();
+                ret.set_i(tid.0);
+            }
+            TraceLowLevelEvent::ThreadSwitch(tid) => {
+                let mut ret = event.init_thread_switch();
+                ret.set_i(tid.0);
+            }
         }
     }
 
@@ -701,6 +713,15 @@ pub fn read_trace(input: &mut impl std::io::BufRead) -> ::capnp::Result<Vec<crat
             }
             Ok(trace::trace_low_level_event::Which::DropVariable(variable_id)) => {
                 TraceLowLevelEvent::DropVariable(crate::VariableId(variable_id?.get_i().try_into().unwrap()))
+            }
+            Ok(trace::trace_low_level_event::Which::ThreadStart(thread_id)) => {
+                TraceLowLevelEvent::ThreadStart(crate::ThreadId(thread_id?.get_i()))
+            }
+            Ok(trace::trace_low_level_event::Which::ThreadExit(thread_id)) => {
+                TraceLowLevelEvent::ThreadExit(crate::ThreadId(thread_id?.get_i()))
+            }
+            Ok(trace::trace_low_level_event::Which::ThreadSwitch(thread_id)) => {
+                TraceLowLevelEvent::ThreadSwitch(crate::ThreadId(thread_id?.get_i()))
             }
             Ok(trace::trace_low_level_event::Which::DropLastStep(())) => TraceLowLevelEvent::DropLastStep,
             Err(_) => {

--- a/runtime_tracing/src/trace.capnp
+++ b/runtime_tracing/src/trace.capnp
@@ -31,6 +31,10 @@ struct Trace {
             variableCell @18 :VariableCellRecord;
             dropVariable @19 :VariableId;
 
+            threadStart @21 :ThreadId;
+            threadExit @22 :ThreadId;
+            threadSwitch @23 :ThreadId;
+
             dropLastStep @20 :Void;
         }
     }
@@ -113,6 +117,10 @@ struct Trace {
 
     struct FunctionId {
         i @0 :Int64;
+    }
+
+    struct ThreadId {
+        i @0 :UInt64;
     }
 
     struct CallRecord {

--- a/runtime_tracing/src/types.rs
+++ b/runtime_tracing/src/types.rs
@@ -49,6 +49,10 @@ pub enum TraceLowLevelEvent {
     VariableCell(VariableCellRecord),
     DropVariable(VariableId),
 
+    ThreadStart(ThreadId),
+    ThreadExit(ThreadId),
+    ThreadSwitch(ThreadId),
+
     // normal event, workaround for cases when we need to drop
     // a step event, but the trace needs to be append-only
     DropLastStep,
@@ -241,6 +245,15 @@ pub struct FunctionId(pub usize);
 
 impl Into<usize> for FunctionId {
     fn into(self) -> usize {
+        self.0
+    }
+}
+
+#[derive(Hash, Debug, Default, Copy, Clone, Serialize, Deserialize, Ord, PartialOrd, Eq, PartialEq)]
+pub struct ThreadId(pub u64);
+
+impl Into<u64> for ThreadId {
+    fn into(self) -> u64 {
         self.0
     }
 }


### PR DESCRIPTION
This will allow multithreading support in interpreters, that use a global lock, such as Ruby (and maybe Python?).

This is *not* intended to be used for languages that run real threads on multiple cores, without a global lock.