### PR TITLE
fix: Windows first-class support improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,9 +22,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -37,15 +37,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -126,7 +126,7 @@ checksum = "eadd868a2ce9ca38de7eeafdcec9c7065ef89b42b32f0839278d55f35c54d1ff"
 dependencies = [
  "clap",
  "heck 0.4.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "proc-macro2",
  "quote",
@@ -148,9 +148,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -178,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -188,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -200,9 +200,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -212,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codetracer_ctfs"
@@ -311,9 +311,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "core-foundation-sys"
@@ -323,9 +323,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "darling"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -333,11 +333,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -347,9 +346,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
@@ -396,21 +395,15 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -469,9 +462,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -540,12 +533,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -558,9 +551,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
@@ -574,9 +567,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -590,9 +583,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "linux-raw-sys"
@@ -614,9 +607,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-derive"
@@ -640,9 +633,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -829,9 +822,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -880,7 +873,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -910,15 +903,15 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.17.0"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
 dependencies = [
  "base64",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -929,9 +922,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.17.0"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -964,9 +957,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
  "getrandom 0.4.2",
@@ -1033,7 +1026,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -1100,9 +1093,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1113,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1123,9 +1116,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1136,9 +1129,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -1160,7 +1153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -1173,7 +1166,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -1282,7 +1275,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -1313,7 +1306,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -1332,7 +1325,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",

--- a/codetracer_trace_types/src/types.rs
+++ b/codetracer_trace_types/src/types.rs
@@ -150,6 +150,7 @@ pub struct FullValueRecord {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TraceMetadata {
+    #[serde(default)]
     pub workdir: PathBuf,
     pub program: String,
     pub args: Vec<String>,

--- a/codetracer_trace_writer_ffi/cbindgen.toml
+++ b/codetracer_trace_writer_ffi/cbindgen.toml
@@ -13,5 +13,14 @@ include = [
     "FfiEventLogKind",
 ]
 
+# Short C-side names so that prefix_with_name produces compact prefixed
+# constants (e.g. TK_ERROR, ELK_ERROR) and avoids the flat-namespace
+# collision between FfiTypeKind::Error and FfiEventLogKind::Error.
+[export.rename]
+"FfiTraceFormat" = "Fmt"
+"FfiTypeKind" = "Tk"
+"FfiEventLogKind" = "Elk"
+
 [enum]
 rename_variants = "ScreamingSnakeCase"
+prefix_with_name = true

--- a/codetracer_trace_writer_ffi/codetracer_trace_writer.h
+++ b/codetracer_trace_writer_ffi/codetracer_trace_writer.h
@@ -13,71 +13,71 @@
 /**
  * Event-log kind — mirrors [`EventLogKind`].
  */
-typedef enum FfiEventLogKind {
-    WRITE = 0,
-    WRITE_FILE = 1,
-    WRITE_OTHER = 2,
-    READ = 3,
-    READ_FILE = 4,
-    READ_OTHER = 5,
-    READ_DIR = 6,
-    OPEN_DIR = 7,
-    CLOSE_DIR = 8,
-    SOCKET = 9,
-    OPEN = 10,
-    ERROR = 11,
-    TRACE_LOG_EVENT = 12,
-    EVM_EVENT = 13,
-} FfiEventLogKind;
+typedef enum Elk {
+    ELK_WRITE = 0,
+    ELK_WRITE_FILE = 1,
+    ELK_WRITE_OTHER = 2,
+    ELK_READ = 3,
+    ELK_READ_FILE = 4,
+    ELK_READ_OTHER = 5,
+    ELK_READ_DIR = 6,
+    ELK_OPEN_DIR = 7,
+    ELK_CLOSE_DIR = 8,
+    ELK_SOCKET = 9,
+    ELK_OPEN = 10,
+    ELK_ERROR = 11,
+    ELK_TRACE_LOG_EVENT = 12,
+    ELK_EVM_EVENT = 13,
+} Elk;
 
 /**
  * Trace file format — mirrors [`TraceEventsFileFormat`].
  */
-typedef enum FfiTraceFormat {
-    JSON = 0,
-    BINARY_V0 = 1,
-    BINARY = 2,
-} FfiTraceFormat;
+typedef enum Fmt {
+    FMT_JSON = 0,
+    FMT_BINARY_V0 = 1,
+    FMT_BINARY = 2,
+} Fmt;
 
 /**
  * Type kind — mirrors [`TypeKind`] (subset used by the FFI).
  */
-typedef enum FfiTypeKind {
-    SEQ = 0,
-    SET = 1,
-    HASH_SET = 2,
-    ORDERED_SET = 3,
-    ARRAY = 4,
-    VARARGS = 5,
-    STRUCT = 6,
-    INT = 7,
-    FLOAT = 8,
-    STRING = 9,
-    C_STRING = 10,
-    CHAR = 11,
-    BOOL = 12,
-    LITERAL = 13,
-    REF = 14,
-    RECURSION = 15,
-    RAW = 16,
-    ENUM = 17,
-    ENUM16 = 18,
-    ENUM32 = 19,
-    C = 20,
-    TABLE_KIND = 21,
-    UNION = 22,
-    POINTER = 23,
-    ERROR = 24,
-    FUNCTION_KIND = 25,
-    TYPE_VALUE = 26,
-    TUPLE = 27,
-    VARIANT = 28,
-    HTML = 29,
-    NONE = 30,
-    NON_EXPANDED = 31,
-    ANY = 32,
-    SLICE = 33,
-} FfiTypeKind;
+typedef enum Tk {
+    TK_SEQ = 0,
+    TK_SET = 1,
+    TK_HASH_SET = 2,
+    TK_ORDERED_SET = 3,
+    TK_ARRAY = 4,
+    TK_VARARGS = 5,
+    TK_STRUCT = 6,
+    TK_INT = 7,
+    TK_FLOAT = 8,
+    TK_STRING = 9,
+    TK_C_STRING = 10,
+    TK_CHAR = 11,
+    TK_BOOL = 12,
+    TK_LITERAL = 13,
+    TK_REF = 14,
+    TK_RECURSION = 15,
+    TK_RAW = 16,
+    TK_ENUM = 17,
+    TK_ENUM16 = 18,
+    TK_ENUM32 = 19,
+    TK_C = 20,
+    TK_TABLE_KIND = 21,
+    TK_UNION = 22,
+    TK_POINTER = 23,
+    TK_ERROR = 24,
+    TK_FUNCTION_KIND = 25,
+    TK_TYPE_VALUE = 26,
+    TK_TUPLE = 27,
+    TK_VARIANT = 28,
+    TK_HTML = 29,
+    TK_NONE = 30,
+    TK_NON_EXPANDED = 31,
+    TK_ANY = 32,
+    TK_SLICE = 33,
+} Tk;
 
 /**
  * Opaque handle passed across the FFI boundary.
@@ -103,7 +103,7 @@ const char *trace_writer_last_error(void);
  * [`trace_writer_free`].  Returns `NULL` on failure (check
  * [`trace_writer_last_error`]).
  */
-struct TraceWriterHandle *trace_writer_new(const char *program, enum FfiTraceFormat format);
+struct TraceWriterHandle *trace_writer_new(const char *program, enum Fmt format);
 
 /**
  * Free a trace writer handle.  Passing `NULL` is a no-op.
@@ -147,7 +147,7 @@ uintptr_t trace_writer_ensure_function_id(struct TraceWriterHandle *handle,
  * Register a type and return its ID.  Returns `usize::MAX` on error.
  */
 uintptr_t trace_writer_ensure_type_id(struct TraceWriterHandle *handle,
-                                      enum FfiTypeKind kind,
+                                      enum Tk kind,
                                       const char *lang_type);
 
 /**
@@ -169,7 +169,7 @@ void trace_writer_register_return(struct TraceWriterHandle *handle);
  */
 void trace_writer_register_return_int(struct TraceWriterHandle *handle,
                                       int64_t value,
-                                      enum FfiTypeKind type_kind,
+                                      enum Tk type_kind,
                                       const char *type_name);
 
 /**
@@ -177,7 +177,7 @@ void trace_writer_register_return_int(struct TraceWriterHandle *handle,
  */
 void trace_writer_register_return_raw(struct TraceWriterHandle *handle,
                                       const char *value_repr,
-                                      enum FfiTypeKind type_kind,
+                                      enum Tk type_kind,
                                       const char *type_name);
 
 /**
@@ -186,7 +186,7 @@ void trace_writer_register_return_raw(struct TraceWriterHandle *handle,
 void trace_writer_register_variable_int(struct TraceWriterHandle *handle,
                                         const char *name,
                                         int64_t value,
-                                        enum FfiTypeKind type_kind,
+                                        enum Tk type_kind,
                                         const char *type_name);
 
 /**
@@ -195,7 +195,7 @@ void trace_writer_register_variable_int(struct TraceWriterHandle *handle,
 void trace_writer_register_variable_raw(struct TraceWriterHandle *handle,
                                         const char *name,
                                         const char *value_repr,
-                                        enum FfiTypeKind type_kind,
+                                        enum Tk type_kind,
                                         const char *type_name);
 
 /**
@@ -206,7 +206,7 @@ void trace_writer_register_variable_raw(struct TraceWriterHandle *handle,
  * string when no metadata is needed.
  */
 void trace_writer_register_special_event(struct TraceWriterHandle *handle,
-                                         enum FfiEventLogKind kind,
+                                         enum Elk kind,
                                          const char *metadata,
                                          const char *content);
 


### PR DESCRIPTION
## Summary
- **Track Cargo.lock** for Nix build compatibility (`buildRustPackage` requires it in-tree)
- **Prefix C enum variants** (TK_, FMT_, ELK_) via cbindgen to avoid flat-namespace collisions that break CGO compilation on Windows (e.g. `FfiTypeKind::Error` and `FfiEventLogKind::Error` both mapping to `ERROR`)
- **Make `TraceMetadata.workdir` optional** with `#[serde(default)]` so older traces without the field still deserialize correctly

## Test plan
- [ ] Verify `cargo build` succeeds and Cargo.lock is up to date
- [ ] Verify the generated C header has prefixed enum constants (no duplicate symbols)
- [ ] Verify deserialization of traces both with and without `workdir` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)