### PR TITLE
[codex] ci: migrate cache reads to Attic

### DIFF
--- a/.github/workflows/codetracer-integration.yml
+++ b/.github/workflows/codetracer-integration.yml
@@ -41,13 +41,12 @@ jobs:
           fi
 
       - name: Setup Nix and Git authentication
-        uses: metacraft-labs/metacraft-github-actions/setup-nix@main
+        uses: metacraft-labs/nixos-modules/.github/setup-nix@main
         with:
-          gh-token: ${{ steps.app-token.outputs.token }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          substituters: ${{ vars.SUBSTITUTERS }}
-          trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
+          push-to-cache: false
+          nix-github-token: ${{ steps.app-token.outputs.token }}
+          substituters: ${{ vars.ATTIC_SUBSTITUTER }}
+          trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
 
       - name: Resolve codetracer ref
         id: resolve-ref

--- a/flake.nix
+++ b/flake.nix
@@ -2,9 +2,9 @@
   description = "CodeTracer Trace Format - Rust crates for trace types, reading, and writing";
 
   nixConfig = {
-    extra-substituters = [ "https://metacraft-labs-codetracer.cachix.org" ];
+    extra-substituters = [ "https://cache.metacraft-labs.com/metacraft-codetracer" ];
     extra-trusted-public-keys = [
-      "metacraft-labs-codetracer.cachix.org-1:6p7pd81m6sIh59yr88yGPU9TFYJZkIrFZoFBWj/y4aE="
+      "metacraft-codetracer:9OV9wCDX560bt5/MrD4dlqnPpCitAEjpoqhNfQpWY3U="
     ];
   };
 


### PR DESCRIPTION
## Summary
- replaces the flake-level binary cache with the metacraft-codetracer Attic cache
- switches the CodeTracer integration workflow to the nixos-modules setup-nix action
- passes Attic substituter/public-key variables into Nix setup with cache pushing disabled

## Validation
- `rg -n 'cachix|Cachix|CACHIX' -S --glob '!flake.lock' .`
- `git diff --check`
- PyYAML parse of `.github/workflows/codetracer-integration.yml`

## Repo settings
The public repo variables `ATTIC_ENDPOINT`, `ATTIC_CACHE`, `ATTIC_SUBSTITUTER`, and `ATTIC_TRUSTED_PUBLIC_KEY` have been set on `metacraft-labs/codetracer-trace-format`.