### PR TITLE
[codex] Use Attic cache in flake nixConfig

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -2,9 +2,9 @@
   description = "CodeTracer Trace Format - Rust crates for trace types, reading, and writing";
 
   nixConfig = {
-    extra-substituters = [ "https://metacraft-labs-codetracer.cachix.org" ];
+    extra-substituters = [ "https://cache.metacraft-labs.com/metacraft-codetracer" ];
     extra-trusted-public-keys = [
-      "metacraft-labs-codetracer.cachix.org-1:6p7pd81m6sIh59yr88yGPU9TFYJZkIrFZoFBWj/y4aE="
+      "metacraft-codetracer:9OV9wCDX560bt5/MrD4dlqnPpCitAEjpoqhNfQpWY3U="
     ];
   };
 


### PR DESCRIPTION
## Summary

- replace legacy Metacraft Cachix nixConfig entries with the corresponding Attic cache substituter and trusted public key
- keep the change scoped to consumer flake cache trust configuration

## Validation

- `attic-migrate-flake`
- `git diff --check`
- `rg -n "cachix.org" flake.nix legacy/flake.nix` where applicable returned no migrated-cache residuals