### PR TITLE
[codex] Migrate Cachix usage to Attic

### DIFF
--- a/.github/workflows/codetracer-integration.yml
+++ b/.github/workflows/codetracer-integration.yml
@@ -44,8 +44,6 @@ jobs:
         uses: metacraft-labs/metacraft-github-actions/setup-nix@main
         with:
           gh-token: ${{ steps.app-token.outputs.token }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
           substituters: ${{ vars.SUBSTITUTERS }}
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
 


### PR DESCRIPTION
## Summary
- replace Cachix cache/deploy usage with Attic cache configuration
- route Nix setup through the shared Attic-aware setup action or repo Attic variables
- remove legacy Cachix push/setup paths where this repo had them

## Validation
- parsed changed GitHub workflow YAML with yq
- parsed changed Nix files with nix-instantiate --parse
- ran git diff --check
