### PR TITLE
ci: migrate CI to self-hosted eph-* runners

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: eph-linux-x64
 
     steps:
       - uses: actions/checkout@v4
@@ -22,7 +22,7 @@ jobs:
         run: just lint
 
   build-and-test:
-    runs-on: ubuntu-latest
+    runs-on: eph-linux-x64
 
     steps:
       - name: Generate CI token

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   windows-test:
-    runs-on: windows-latest
+    runs-on: eph-win-x64
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Migrate GitHub-hosted CI runners to Metacraft Labs self-hosted `eph-*` classes, per org policy (all CI on self-hosted eph-* classes; GitHub-hosted not permitted).

- `rust.yml` (lint job): `ubuntu-latest` → `eph-linux-x64`
- `rust.yml` (build-and-test job): `ubuntu-latest` → `eph-linux-x64`
- `windows-tests.yml` (windows-test job): `windows-latest` → `eph-win-x64`

`codetracer-integration.yml` was already on `[self-hosted, nixos]` and is untouched. Comment lines and existing labels preserved; YAML structure unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)