### PR TITLE
fix(writer-nim): align the MSVC runtime library

### DIFF
--- a/codetracer_trace_writer_nim/build.rs
+++ b/codetracer_trace_writer_nim/build.rs
@@ -146,8 +146,11 @@ fn main() {
     }
     if msvc {
         // MSVC-ABI consumer: Nim must emit MSVC objects (it defaults to
-        // MinGW gcc on Windows).
+        // MinGW gcc on Windows). cl.exe defaults to the static CRT (/MT),
+        // while Rust's MSVC target defaults to the dynamic CRT, so align the
+        // Nim objects explicitly to avoid an LNK2038 RuntimeLibrary mismatch.
         nim.arg("--cc:vcc");
+        nim.arg("--passC:-MD");
     } else if windows {
         // windows-gnu consumer: MinGW gcc objects (ABI-compatible with the
         // x86_64-pc-windows-gnu Rust target).


### PR DESCRIPTION
## Summary
- compile the Nim-backed writer with the dynamic MSVC runtime selected by Rust's default Windows target
- document the `/MT` versus `/MD` mismatch that otherwise produces LNK2038

## Verification
- `cargo test -p codetracer_trace_writer_nim` under Visual Studio 2022 Developer PowerShell (16 passed)
- `rustfmt --check codetracer_trace_writer_nim/build.rs`