### PR TITLE
ci: run CI on `dev` and `stable`, not just `main`

### DIFF
--- a/.github/workflows/codetracer-integration.yml
+++ b/.github/workflows/codetracer-integration.yml
@@ -3,7 +3,7 @@ name: CodeTracer Integration Tests
 on:
   pull_request:
   push:
-    branches: [main, master]
+    branches: [main, master, dev, stable]
   workflow_dispatch:
     inputs:
       codetracer_ref:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,7 @@ name: Rust
 
 on:
   push:
-    branches: ["master", "main"]
+    branches: ["master", "main", "dev", "stable"]
   pull_request:
 
 env:

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -1,7 +1,7 @@
 name: Windows Tests
 on:
   push:
-    branches: [main]
+    branches: [main, dev, stable]
   pull_request:
 
 jobs:


### PR DESCRIPTION
`main` was frozen around 2026-07-11/13 when this repo's default moved to `stable`,
but the workflow branch filters were never updated. The result is **unchecked mainline**.

## Evidence

Run counts from the Actions API, not read off the YAML:

| query | result |
|---|---|
| runs of these workflows on `stable`, ever | **0** |

| workflow | impact | last 3 runs |
|---|---|---|
| `codetracer-integration.yml` | push-only | 2026-08-15:pull_request:failure | 2026-07-31:pull_request:failure | 2026-07-11:push:failure |
| `rust.yml` | push-only | 2026-08-15:pull_request:failure | 2026-07-31:pull_request:failure | 2026-07-11:push:success |
| `windows-tests.yml` | push-only | 2026-08-15:pull_request:failure | 2026-07-31:pull_request:failure | 2026-07-11:push:success |

`push-only` means an unfiltered `pull_request:` kept PR coverage alive, so only
direct pushes to the mainline went unchecked. `TOTAL BLACKOUT` means the
`pull_request: branches:` filter *also* named a base no PR targets, so neither
path ran.

## Change

Branch filters widened to `[main, dev, stable]`, matching the convention
already used in `term-assert-cmd`, which was never broken. `main` is kept
because the branch still exists; `stable` is included for consistency with the
reference even where it does not exist yet — a filter naming an absent branch
simply never matches.

## ⚠️ Expect red, and that is the point

The last real conclusion for these workflows is `failure` in almost every case
(see the table). This change does not introduce those failures — it makes a
mainline that has been unchecked since mid-July report its true state for the
first time.

**Please do not revert this as a breakage.** Reverting restores the blackout
rather than fixing anything. I deliberately did not add `continue-on-error`,
`|| true`, or any other softening to make the first run look green.

## Merge readiness

The runner fleet is capacity-capped — the `eph-*` classes are served only by 8
ephemeral GARM runners, which are currently saturated, and `eph-macos-arm64`
scale sets are not being created at all (infra #1308). **A queued check is not
a passing check.** If checks here sit pending, that is scheduling, not success.

The trigger change is verifiable by reading the diff; all changed files parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)