### PR TITLE
nix: buildRustPackage for codetracer-managed-upload (Phase 2, draft)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,8 +28,48 @@
         { pkgs, system, ... }:
         let
           toolchainsPkgs = inputs."codetracer-toolchains".packages.${system};
+
+          # VERIFY(linux): rust-stable is a combined toolchain derivation;
+          # makeRustPlatform expects it to expose `cargo` + `rustc` on PATH.
+          # If the attr split differs, pass `toolchainsPkgs.rust-stable` as
+          # both (works when it bundles both) or use pkgs.rustPlatform.
+          rustPlatform = pkgs.makeRustPlatform {
+            cargo = toolchainsPkgs.rust-stable;
+            rustc = toolchainsPkgs.rust-stable;
+          };
+
+          # `codetracer-managed-upload` lives in the `codetracer_ctfs` crate.
+          # Its dependency closure is crates.io + `zstd` only — NO in-repo
+          # path deps — so building just this bin does NOT trigger the nim
+          # staticlib (codetracer_trace_writer_nim/build.rs) or capnpc
+          # (codetracer_trace_format_capnp/build.rs). The build is therefore
+          # self-contained: rust + libzstd + pkg-config.
+          codetracer-managed-upload = rustPlatform.buildRustPackage {
+            pname = "codetracer-managed-upload";
+            version = "0.1.0";
+            src = ./.;
+            cargoLock.lockFile = ./Cargo.lock; # all registry deps (no git+ → no outputHashes needed)
+            # Restrict the whole virtual workspace to just this one binary so
+            # the nim/capnp `build.rs` crates never enter the build graph.
+            cargoBuildFlags = [
+              "-p"
+              "codetracer_ctfs"
+              "--bin"
+              "codetracer-managed-upload"
+            ];
+            doCheck = false; # unit tests need live fixtures; keep the package lean
+            nativeBuildInputs = [ pkgs.pkg-config ];
+            buildInputs = [ pkgs.zstd ];
+            PKG_CONFIG_PATH = "${pkgs.zstd.dev}/lib/pkgconfig";
+            meta.mainProgram = "codetracer-managed-upload";
+          };
         in
         {
+          packages = {
+            inherit codetracer-managed-upload;
+            default = codetracer-managed-upload;
+          };
+
           devShells.default = pkgs.mkShell {
             packages = [
               # Rust toolchain

--- a/repro.nim
+++ b/repro.nim
@@ -155,6 +155,29 @@ package codetracer_trace_format:
       extraInputs = workspaceInputs)
     discard collect("default", @[workspaceBuild])
 
+    # ---- Granular targeted binary: codetracer-managed-upload ----------
+    #
+    # codetracer-ci consumes ONLY this one binary (built from source via
+    # the flake's buildRustPackage). Emit a dedicated edge restricted to
+    # the ``codetracer_ctfs`` member crate + its ``codetracer-managed-upload``
+    # bin so ``repro build .#managed-upload`` (and downstream consumers)
+    # rebuild just this artifact instead of the whole 16-crate workspace.
+    # ``codetracer_ctfs``'s dep closure is crates.io + ``zstd`` only — no
+    # in-repo ``path`` deps — so it does NOT pull in the nim-staticlib
+    # (``codetracer_trace_writer_nim``) or capnpc (``codetracer_trace_format_capnp``)
+    # ``build.rs`` edges, and the declared input set is just that crate.
+    #
+    # Requires the ``--package``/``--bin`` cargo selectors added in
+    # reprobuild#84 (bump the reprobuild pin before this edge resolves).
+    let managedUploadBuild = cargo.build(
+      locked = true,
+      release = true,
+      package = "codetracer_ctfs",
+      bin = "codetracer-managed-upload",
+      actionId = "codetracer-trace-format.managed-upload",
+      extraInputs = @["Cargo.toml", "Cargo.lock", "codetracer_ctfs"])
+    discard collect("managed-upload", @[managedUploadBuild])
+
     # ---- Test-binary build + run edges (the `test` collection) -------
     #
     # Two-stage shape per Repo-Requirements.md §2.8: ``cargo.test(noRun =


### PR DESCRIPTION
Adds `packages.{codetracer-managed-upload,default}` so the binary builds from source instead of being consumed as a prebuilt `target/release/` path by the codetracer-ci flake (part of the build-from-source plan, codetracer-ci `nix/portable-artifacts-and-reprobuild.plan.md` Phase 2).

**Key simplification:** `codetracer_ctfs` (the crate owning the bin) has **no in-repo path deps** (crates.io + `zstd` only), so restricting to `-p codetracer_ctfs --bin codetracer-managed-upload` avoids the nim-staticlib + capnpc `build.rs` edges entirely — self-contained (rust + libzstd + pkg-config).

⚠️ **Draft — not built on the authoring machine (macOS, no nix eval).** VERIFY on Linux:
1. `makeRustPlatform` cargo/rustc split for `rust-stable`
2. `zstd-sys` links system libzstd via pkg-config (else it vendors)
3. `nix build .#codetracer-managed-upload && ./result/bin/codetracer-managed-upload --help`